### PR TITLE
fix(backend): Fix response content type empty cart

### DIFF
--- a/backend/src/routes/basket/mod.rs
+++ b/backend/src/routes/basket/mod.rs
@@ -52,6 +52,7 @@ async fn get(data: web::Data<AppState>, logged_user: LoggedUser) -> crate::Resul
         (
             status = 200,
             description="Basket successfully emptied",
+            body=String,
         ),
     ),
 )]


### PR DESCRIPTION
Empty cart route did not specify return type.